### PR TITLE
Parse JSON response with Bigdecimal to maintain precision

### DIFF
--- a/lib/mcoin/influx_db.rb
+++ b/lib/mcoin/influx_db.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pp'
+require 'bigdecimal'
 require 'net/http'
 
 module Mcoin
@@ -19,7 +20,7 @@ module Mcoin
         http.request(req)
       end
 
-      pp JSON.parse(res.body) unless res.body.nil?
+      pp JSON.parse(res.body, decimal_class: BigDecimal) unless res.body.nil?
     end
 
     protected

--- a/lib/mcoin/market/base.rb
+++ b/lib/mcoin/market/base.rb
@@ -2,6 +2,7 @@
 
 require 'pp'
 require 'json'
+require 'bigdecimal'
 require 'net/http'
 
 module Mcoin
@@ -19,7 +20,7 @@ module Mcoin
       end
 
       def fetch
-        @data ||= JSON.parse(Net::HTTP.get(uri))
+        @data ||= JSON.parse(Net::HTTP.get(uri), decimal_class: BigDecimal)
         self
       rescue JSON::ParserError
         return nil if @retries >= 3


### PR DESCRIPTION
Currently `decimal` date in JSON response is parsed with `Float`, which result in precision lost.

`:decimal_class` options was introduced in [`json`](https://github.com/flori/json) to resolved this issue [in `json` version 2.1.0 on April 18th, 2017](https://github.com/flori/json/blob/master/CHANGES.md).
